### PR TITLE
fix(numberInput): avoid parsing value

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@indec/react-commons",
-  "version": "5.6.1",
+  "version": "5.7.0",
   "description": "Common reactjs components for apps",
   "private": false,
   "main": "index.js",

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -38,15 +38,16 @@ const NumberInput = ({
     const isEmptyStringFieldValue = field?.value === '';
 
     const handleChangeValue = newValue => {
-        const hasDecimals = hasDecimal ? newValue: Number(newValue)
+        const hasDecimals = hasDecimal ? newValue : Number(newValue);
         const changedValue = newValue === '' ? '' : hasDecimals;
         if (field) {
             setField(field.name, changedValue, form.setFieldValue);
         } else {
             handleChange(
-                { target:{ id: name, value: changedValue } },
+                {target: {id: name, value: changedValue}},
                 onChange
-            )}
+            );
+        }
     };
 
     return (

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -23,6 +23,7 @@ const NumberInput = ({
     quote,
     containerStyle,
     onChange,
+    hasDecimal,
     iconLeft,
     iconRight,
     hasError,
@@ -36,16 +37,16 @@ const NumberInput = ({
     const [handleChange, error, setField] = useError(hasError);
     const isEmptyStringFieldValue = field?.value === '';
 
-    const onHandleChange = newValue => {
-        const isNewValue = newValue === '' ? '' : newValue;
+    const handleChangeValue = newValue => {
+        const hasDecimals = hasDecimal ? newValue: Number(newValue)
+        const changedValue = newValue === '' ? '' : hasDecimals;
         if (field) {
-            setField(field.name, isNewValue, form.setFieldValue);
+            setField(field.name, changedValue, form.setFieldValue);
         } else {
             handleChange(
-                {target: {id: name, value: isNewValue}},
+                { target:{ id: name, value: changedValue } },
                 onChange
-            );
-        }
+            )}
     };
 
     return (
@@ -65,7 +66,7 @@ const NumberInput = ({
                 variant={variant}
                 value={field?.value === 0 ? field.value : field?.value || value}
                 onKeyDown={e => e.key === 'e' && e.preventDefault()}
-                onChange={onHandleChange}
+                onChange={handleChangeValue}
                 {...props}
             >
                 <NumberInputField data-testid={`input-${field?.name || name}`} placeholder={placeholder}/>
@@ -82,6 +83,7 @@ const NumberInput = ({
 
 NumberInput.propTypes = {
     name: PropTypes.string,
+    hasDecimal: PropTypes.bool,
     placeholder: PropTypes.string,
     variant: PropTypes.string,
     isDisabled: PropTypes.bool,
@@ -108,6 +110,7 @@ NumberInput.propTypes = {
 };
 
 NumberInput.defaultProps = {
+    hasDecimal: false,
     name: undefined,
     width: undefined,
     containerStyle: {},

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -53,12 +53,14 @@ const NumberInput = ({
                 variant={variant}
                 value={field?.value === 0 ? field.value : field?.value || value}
                 onKeyDown={e => e.key === 'e' && e.preventDefault()}
+                step={0.01}
+                min={-9999.99} 
                 onChange={newValue => {
                     if (field) {
-                        setField(field.name, newValue === '' ? '' : Number(newValue), form.setFieldValue);
+                        setField(field.name, newValue === '' ? '' : newValue, form.setFieldValue);
                     } else {
                         handleChange(
-                            {target: {id: name, value: newValue === '' ? '' : Number(newValue)}},
+                            {target: {id: name, value: newValue === '' ? '' : newValue}},
                             onChange
                         );
                     }

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -36,6 +36,18 @@ const NumberInput = ({
     const [handleChange, error, setField] = useError(hasError);
     const isEmptyStringFieldValue = field?.value === '';
 
+    const onHandleChange = (newValue) => {
+        const value = newValue === '' ? '' : newValue
+        if (field) {
+            setField(field.name, value, form.setFieldValue);
+        } else {
+            handleChange(
+                {target: {id: name, value}},
+                onChange
+            );
+        }
+    }
+
     return (
         <FormControl
             name={field?.name || name}
@@ -53,16 +65,7 @@ const NumberInput = ({
                 variant={variant}
                 value={field?.value === 0 ? field.value : field?.value || value}
                 onKeyDown={e => e.key === 'e' && e.preventDefault()}
-                onChange={newValue => {
-                    if (field) {
-                        setField(field.name, newValue === '' ? '' : newValue, form.setFieldValue);
-                    } else {
-                        handleChange(
-                            {target: {id: name, value: newValue === '' ? '' : newValue}},
-                            onChange
-                        );
-                    }
-                }}
+                onChange={onHandleChange}
                 {...props}
             >
                 <NumberInputField data-testid={`input-${field?.name || name}`} placeholder={placeholder}/>

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -38,8 +38,8 @@ const NumberInput = ({
     const isEmptyStringFieldValue = field?.value === '';
 
     const handleChangeValue = newValue => {
-        const hasDecimals = hasDecimal ? newValue : Number(newValue);
-        const changedValue = newValue === '' ? '' : hasDecimals;
+        const formatedValue = hasDecimal ? newValue : Number(newValue);
+        const changedValue = newValue === '' ? '' : formatedValue;
         if (field) {
             setField(field.name, changedValue, form.setFieldValue);
         } else {

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -36,17 +36,17 @@ const NumberInput = ({
     const [handleChange, error, setField] = useError(hasError);
     const isEmptyStringFieldValue = field?.value === '';
 
-    const onHandleChange = (newValue) => {
-        const value = newValue === '' ? '' : newValue
+    const onHandleChange = newValue => {
+        const isNewValue = newValue === '' ? '' : newValue;
         if (field) {
-            setField(field.name, value, form.setFieldValue);
+            setField(field.name, isNewValue, form.setFieldValue);
         } else {
             handleChange(
-                {target: {id: name, value}},
+                {target: {id: name, value: isNewValue}},
                 onChange
             );
         }
-    }
+    };
 
     return (
         <FormControl

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -54,7 +54,6 @@ const NumberInput = ({
                 value={field?.value === 0 ? field.value : field?.value || value}
                 onKeyDown={e => e.key === 'e' && e.preventDefault()}
                 step={0.01}
-                min={-9999.99} 
                 onChange={newValue => {
                     if (field) {
                         setField(field.name, newValue === '' ? '' : newValue, form.setFieldValue);

--- a/src/components/NumberInput/NumberInput.js
+++ b/src/components/NumberInput/NumberInput.js
@@ -53,7 +53,6 @@ const NumberInput = ({
                 variant={variant}
                 value={field?.value === 0 ? field.value : field?.value || value}
                 onKeyDown={e => e.key === 'e' && e.preventDefault()}
-                step={0.01}
                 onChange={newValue => {
                     if (field) {
                         setField(field.name, newValue === '' ? '' : newValue, form.setFieldValue);

--- a/src/components/NumberInput/NumberInput.test.js
+++ b/src/components/NumberInput/NumberInput.test.js
@@ -1,9 +1,4 @@
-import {
-    fireEvent,
-    getByTestId,
-    getByPlaceholderText,
-    waitFor
-} from '@testing-library/react';
+import {fireEvent, getByTestId} from '@testing-library/react';
 import {NumberInput} from '@/components';
 
 describe('<NumberInput>', () => {
@@ -11,7 +6,8 @@ describe('<NumberInput>', () => {
     const getComponent = () => render(NumberInput, props, {formik: {}});
     beforeEach(() => {
         props = {
-            name: 'test'
+            name: 'test',
+            onChange: jest.fn()
         };
     });
     afterEach(tearDown);
@@ -39,18 +35,31 @@ describe('<NumberInput>', () => {
         });
     });
 
-    describe('when `props.hasDecimal` is true', () => {
+    describe('when `props.hasDecimal` is `true`', () => {
         beforeEach(() => {
             props.hasDecimal = true;
+            const {container} = getComponent();
+            const input = getByTestId(container, 'input-test');
+            fireEvent.change(input, {target: {value: 11.22}});
         });
 
-        it('should be with decimals', () => {
+        it('should fire `props.onChange` with value as string', () => {
+            expect(props.onChange).toHaveBeenCalled();
+            expect(props.onChange).toHaveBeenCalledWith({target: {id: 'test', value: '11.22'}});
+        });
+    });
+
+    describe('when `props.hasDecimal` is `false`', () => {
+        beforeEach(() => {
+            props.hasDecimal = false;
             const {container} = getComponent();
-            const input = getByPlaceholderText(container, 'Ingrese');
+            const input = getByTestId(container, 'input-test');
             fireEvent.change(input, {target: {value: 11.22}});
-            waitFor(() => {
-                expect(input).toHaveValue(11.22);
-            });
+        });
+
+        it('should fire `props.onChange` with value as number', () => {
+            expect(props.onChange).toHaveBeenCalled();
+            expect(props.onChange).toHaveBeenCalledWith({target: {id: 'test', value: 11.22}});
         });
     });
 });

--- a/src/components/NumberInput/NumberInput.test.js
+++ b/src/components/NumberInput/NumberInput.test.js
@@ -1,4 +1,4 @@
-import {getByTestId} from '@testing-library/react';
+import {fireEvent, getByTestId, getByPlaceholderText, waitFor} from '@testing-library/react';
 
 import {NumberInput} from '@/components';
 
@@ -33,5 +33,20 @@ describe('<NumberInput>', () => {
             const label = getByTestId(container, 'label-test');
             expect(label).toHaveTextContent('Test');
         });
+    });
+
+    describe('when `props.hasDecimal` is true', () => {
+        beforeEach(() => {
+            props.hasDecimal = true;
+        });
+
+        it('should be with decimals', () => {
+            const {container} = getComponent();
+            const input = getByPlaceholderText(container, 'Ingrese');
+            fireEvent.change(input, { target: { value: 11.22 }});
+            waitFor(() => {
+                expect(input).toHaveValue(11.22);
+              });
+          });
     });
 });

--- a/src/components/NumberInput/NumberInput.test.js
+++ b/src/components/NumberInput/NumberInput.test.js
@@ -1,5 +1,9 @@
-import {fireEvent, getByTestId, getByPlaceholderText, waitFor} from '@testing-library/react';
-
+import {
+    fireEvent,
+    getByTestId,
+    getByPlaceholderText,
+    waitFor
+} from '@testing-library/react';
 import {NumberInput} from '@/components';
 
 describe('<NumberInput>', () => {
@@ -43,10 +47,10 @@ describe('<NumberInput>', () => {
         it('should be with decimals', () => {
             const {container} = getComponent();
             const input = getByPlaceholderText(container, 'Ingrese');
-            fireEvent.change(input, { target: { value: 11.22 }});
+            fireEvent.change(input, {target: {value: 11.22}});
             waitFor(() => {
                 expect(input).toHaveValue(11.22);
-              });
-          });
+            });
+        });
     });
 });


### PR DESCRIPTION
# Description

Added a new prop called `hasDecimals` to check if the number input's value should be parsed or not

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How to test

1. Run `npm run test`