### PR TITLE
feat(table): add logic to paint free rows

### DIFF
--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -36,7 +36,6 @@ const Table = ({
     showDefaultFooter,
     showPagination,
     total,
-    paintFreeRowsColor,
     ...props
 }) => {
     const columnsData = Array.isArray(columns) ? columns : [];
@@ -117,9 +116,9 @@ const Table = ({
                             <Tr key={row?.key} {...row?.containerStyle} data-testid={`row-${row?.key}`}>
                                 {columnsData.map(header => {
                                     const isEmpty = row[header.key] == null || row[header.key] === '';
-                                    const updatRowsStyle = isEmpty ? header.emptyRow : header.tdStyle;
+                                    const rowStyle = isEmpty ? header.emptyRow : header.tdStyle;
                                     return (
-                                        <Td key={`${row.key}-${header.key}`} {...row.style} {...updatRowsStyle}>
+                                        <Td key={`${row.key}-${header.key}`} {...row.style} {...rowStyle}>
                                             {row[header.key]}
                                         </Td>
                                     );
@@ -145,7 +144,6 @@ const Table = ({
 };
 
 Table.propTypes = {
-    paintFreeRowsColor: PropTypes.string,
     caption: PropTypes.string,
     columns: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     data: PropTypes.arrayOf(PropTypes.shape({})),
@@ -170,15 +168,14 @@ Table.defaultProps = {
     emptyMessage: 'No hay resultados',
     isLoading: false,
     name: 'table',
-    onSearch: () => { },
+    onSearch: () => {},
     onSort: undefined,
     paginationStyles: undefined,
     params: undefined,
     perPage: 0,
     showDefaultFooter: true,
     showPagination: true,
-    total: 0,
-    paintFreeRowsColor: undefined
+    total: 0
 };
 
 export default Table;

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -36,6 +36,7 @@ const Table = ({
     showDefaultFooter,
     showPagination,
     total,
+    paintFreeRowsColor,
     ...props
 }) => {
     const columnsData = Array.isArray(columns) ? columns : [];
@@ -114,11 +115,16 @@ const Table = ({
                         )}
                         {!isLoading && data.length > 0 && buildRows(data, columnsData).map(row => (
                             <Tr key={row?.key} {...row?.containerStyle} data-testid={`row-${row?.key}`}>
-                                {columnsData.map(header => (
-                                    <Td key={`${row.key}-${header.key}`} {...row.style} {...header.tdStyle} >
-                                        {row[header.key]}
-                                    </Td>
-                                ))}
+                                {columnsData.map(header => {
+                                    const isEmpty = row[header.key] == null || row[header.key] === '';
+                                    const rowsStyle = isEmpty && paintFreeRowsColor !== undefined
+                                        ? {backgroundColor: `${paintFreeRowsColor}`} : (row.style || '');
+                                    return (
+                                        <Td key={`${row.key}-${header.key}`} {...rowsStyle} {...header.tdStyle}>
+                                            {row[header.key]}
+                                        </Td>
+                                    );
+                                })}
                             </Tr>
                         ))}
                     </Tbody>
@@ -140,6 +146,7 @@ const Table = ({
 };
 
 Table.propTypes = {
+    paintFreeRowsColor: PropTypes.string,
     caption: PropTypes.string,
     columns: PropTypes.arrayOf(PropTypes.shape({})).isRequired,
     data: PropTypes.arrayOf(PropTypes.shape({})),
@@ -164,14 +171,15 @@ Table.defaultProps = {
     emptyMessage: 'No hay resultados',
     isLoading: false,
     name: 'table',
-    onSearch: () => {},
+    onSearch: () => { },
     onSort: undefined,
     paginationStyles: undefined,
     params: undefined,
     perPage: 0,
     showDefaultFooter: true,
     showPagination: true,
-    total: 0
+    total: 0,
+    paintFreeRowsColor: undefined
 };
 
 export default Table;

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -117,10 +117,9 @@ const Table = ({
                             <Tr key={row?.key} {...row?.containerStyle} data-testid={`row-${row?.key}`}>
                                 {columnsData.map(header => {
                                     const isEmpty = row[header.key] == null || row[header.key] === '';
-                                    const rowsStyle = isEmpty && paintFreeRowsColor !== undefined
-                                        ? {backgroundColor: `${paintFreeRowsColor}`} : (row.style || '');
+                                    const updatRowsStyle = isEmpty ? header.emptyRow : header.tdStyle;
                                     return (
-                                        <Td key={`${row.key}-${header.key}`} {...rowsStyle} {...header.tdStyle}>
+                                        <Td key={`${row.key}-${header.key}`} {...row.style} {...updatRowsStyle}>
                                             {row[header.key]}
                                         </Td>
                                     );

--- a/src/theme/components/table.js
+++ b/src/theme/components/table.js
@@ -29,6 +29,34 @@ const table = {
                 textAlign: 'left',
                 padding: '10px 20px'
             }
+        },
+        fixedFirstColumn: {
+            fontSize: '16px',
+            height: '35px',
+            table: {
+                background: 'white',
+                borderRadius: '0 0 10px 10px'
+            },
+            tr: {
+                '& th:first-of-type': {
+                    position: 'sticky',
+                    left: '0',
+                    backgroundColor: 'white'
+                },
+                '&:nth-of-type(even) td:first-of-type ': {
+                    backgroundColor: 'brand.neutral50'
+                },
+                '&:nth-of-type(odd) td:first-of-type ': {
+                    backgroundColor: 'white'
+                }
+            },
+
+            td: {
+                '&:first-of-type': {
+                    position: 'sticky',
+                    left: '0'
+                }
+            }
         }
     }
 };

--- a/src/theme/components/table.js
+++ b/src/theme/components/table.js
@@ -29,34 +29,6 @@ const table = {
                 textAlign: 'left',
                 padding: '10px 20px'
             }
-        },
-        fixedFirstColumn: {
-            fontSize: '16px',
-            height: '35px',
-            table: {
-                background: 'white',
-                borderRadius: '0 0 10px 10px'
-            },
-            tr: {
-                '& th:first-of-type': {
-                    position: 'sticky',
-                    left: '0',
-                    backgroundColor: 'white'
-                },
-                '&:nth-of-type(even) td:first-of-type ': {
-                    backgroundColor: 'brand.neutral50'
-                },
-                '&:nth-of-type(odd) td:first-of-type ': {
-                    backgroundColor: 'white'
-                }
-            },
-
-            td: {
-                '&:first-of-type': {
-                    position: 'sticky',
-                    left: '0'
-                }
-            }
         }
     }
 };


### PR DESCRIPTION
# Description

Add a new variant and property to paint the free rows of the table component 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How to test

1. List instructions for how to test
1. Make sure it's detailed and includes the exact steps